### PR TITLE
always check bogus fix keywords when matching 'fix' or 'bug'

### DIFF
--- a/bohr/heuristics/keywords/bug.kwords
+++ b/bohr/heuristics/keywords/bug.kwords
@@ -1,6 +1,6 @@
 bad
 broken
-bug|bugg
+bugg
 close
 concurr
 correct|correctli
@@ -14,7 +14,7 @@ ensur
 error
 except
 fail|failur|fault
-fix|hotfix|quickfix|small fix
+hotfix|quickfix|small fix
 garbag
 handl
 incomplet


### PR DESCRIPTION
**Before**:
For "Fix" message - 2 `bug` labels would be assigned 
For "Fix unit-test" message -  1 `bug` and 1  `bugless` would be assigned

**Now**:
For "Fix" message - 1 `bug` label would be assigned 
For "Fix unit-test" message -  1  `bugless` would be assigned